### PR TITLE
SCRUM-70: Have delete text box go away after deleting a task on the calendar

### DIFF
--- a/my-app1/app/(dashboard)/calendar/Calender.tsx
+++ b/my-app1/app/(dashboard)/calendar/Calender.tsx
@@ -160,10 +160,13 @@ export function Calendar() {
       const taskRef = ref(db, `ServiceSync/${selectedTask.id}`);
       await remove(taskRef);
       setTasks(tasks.filter((t) => t.id !== selectedTask.id));
+      handleCloseDeleteDialog(); // Close the delete dialog after deletion
+      handleCloseModifyDialog(); // Close the modify dialog after deletion
     } catch (error) {
       console.error('Error deleting task:', error);
     }
   };
+  
 
   const handleEventClick = (arg: EventClickArg) => {
     const task = tasks.find((t) => t.id === arg.event.id);


### PR DESCRIPTION
The delete function for the calendar was missing the lines of code to close both of the dialog boxes so I just added those into the function. JIRA task link: https://csus-best-effort.atlassian.net/browse/SCRUM-70?atlOrigin=eyJpIjoiOTI1NDZhYjFjYzAxNGIzMDkzZGY2NGNmYzU2NzEyMDEiLCJwIjoiaiJ9