### PR TITLE
db was initialized twice, threw errors fixed it

### DIFF
--- a/my-app1/app/(dashboard)/editProfile/lib/firebase.ts
+++ b/my-app1/app/(dashboard)/editProfile/lib/firebase.ts
@@ -13,7 +13,7 @@ const firebaseConfig = {
   measurementId:process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID
   };
 
-const app = initializeApp(firebaseConfig);
+const app = initializeApp(firebaseConfig, "service_sync");
 const db = getDatabase(app);
 
 export { db };

--- a/my-app1/app/(dashboard)/serviceStatus/page.tsx
+++ b/my-app1/app/(dashboard)/serviceStatus/page.tsx
@@ -11,7 +11,7 @@ import ErrorIcon from "@mui/icons-material/Error";
 import { useTheme } from "@mui/material/styles";
 import { ThemeProvider } from "@mui/material/styles";
 import { ref, get } from "firebase/database"; // Firebase imports
-import { db } from "../../../auth"; // Ensure this path matches your Firebase config
+import { db } from "../editProfile/lib/firebase"; // Ensure this path matches your Firebase config
 
 export default function ServiceStatusPage() {
   const [appStatus, setAppStatus] = React.useState<"online" | "offline">("online"); // Always online

--- a/my-app1/auth.ts
+++ b/my-app1/auth.ts
@@ -4,16 +4,7 @@ import type { Provider } from 'next-auth/providers';
 import { initializeApp } from 'firebase/app';
 import { ref, query, getDatabase, orderByChild, equalTo, get } from 'firebase/database';
 import { use } from 'react';
-
-const firebaseConfig = {
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
-  databaseURL: process.env.NEXT_PUBLIC_FIREBASE_DATABASE_URL,
-};
+import { db } from './app/(dashboard)/editProfile/lib/firebase'
 
 interface User {
   name: string;
@@ -22,9 +13,12 @@ interface User {
   email: string;
 }
 
-// Initialize Firebase
-const app = initializeApp(firebaseConfig);
-export const db = getDatabase(app);
+// This is the db name assigned in the firebase.ts file.
+if (db.app.name != 'service_sync') {
+  //This is an error, the db should already be loaded and not unloaded.
+  console.error('Error, program says db is not loaded.');
+  throw new Error('Database is not loading properly refer to duplicate declarations of db in application.');
+}
 
 async function findAuthEntry(email: string, password: string): Promise<boolean> {
   try {


### PR DESCRIPTION
When I would open the app, the system status would throw an error as well as some other pages. This was due to duplicate db's initializing more than once. I removed that code and had it refer to the same db with an import statement. Additionally, I had to do a check in one file to ensure that the db being referred to wasn't already created, and if it was then to throw an error. This solved the problem. In addition, I had one file fix the reference to the db which previously was referencing the duplicate db instance.